### PR TITLE
Fix missing Prometheus config

### DIFF
--- a/monitoramento/prometheus.yml
+++ b/monitoramento/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']


### PR DESCRIPTION
## Summary
- add `monitoramento/prometheus.yml` so docker-compose can mount the Prometheus config

## Testing
- `git status --short`

------
